### PR TITLE
Fix AJAX URL by removing trailing slash related to 'validate_common_value' view 

### DIFF
--- a/static/assets/js/manifests.js
+++ b/static/assets/js/manifests.js
@@ -825,7 +825,7 @@ function validateCommonValue(e, data) {
         // now that the common value is neither undefined, null or empty i.e. it has a value
         $.ajax({
           type: 'GET',
-          url: '/manifests/validate_common_value/',
+          url: '/manifests/validate_common_value',
           dataType: 'json',
           data: {
             commonField: commonField,


### PR DESCRIPTION
# COPO Pull Request

## Title
<em>Prevent the 404 error in prefilled manifest wizard</em>

---

## Jira Link
<em>https://earlham-institute.atlassian.net/browse/CD-164?atlOrigin=eyJpIjoiYzk5OTVmMWZhMTZkNDMxMDgyOTZlNDdlMzdhYTE2YmEiLCJwIjoiaiJ9</em>

<em>Removed trailing slash from AJAX URL to match the corresponding URL</em>

---

## Summary of Changes
<em>Removed unnecessary slash</em>
<em>For example, this fix allowed the URL to change from `https://copo-project.org/manifests/validate_common_value/?commonField=FAMILY&commonValue=ynnr` to `https://copo-project.org/manifests/validate_common_value?commonField=FAMILY&commonValue=ynnr` where the latter is correct.</em>

---

## Checklist Before Requesting Review

- [ ] Jira ticket is in the correct state  
- [ ] Change meets the acceptance criteria  
- [ ] Manual test plan has been followed and passed  
- [ ] No debug prints or experimental code left in  
- [ ] API or schema changes documented  

---

## Testing Evidence
<em>The prefilled manifest wizard validation can proceed beyond step 2 which is about filling in common values that should be within each column in the manifest.</em>

---

## Reviewer Notes
<em>Highlight anything the reviewer should pay special attention to.  
Mention any technical debt you are aware of but not resolving here.</em>

---

## Review Responsibilities

- Developer pull requests: reviewed by Senior Developer  
- Senior Developer's pull requests: reviewed by Manager 
- Manager's pull requests: reviewed by Senior Developer

Confirm the correct reviewer is assigned.

---

## Deployment Notes
Note whether this change requires config updates, migrations, restarts, or downstream updates.

---

## After Approval

- Move the Jira ticket to the next state  

