### PR TITLE
CD-183: Correct error message in optional field validation

### DIFF
--- a/src/apps/copo_dtol_upload/utils/tol_validators/optional_field_dtol_validators.py
+++ b/src/apps/copo_dtol_upload/utils/tol_validators/optional_field_dtol_validators.py
@@ -397,7 +397,7 @@ class DtolEnumerationValidator(Validator):
                             regex_rule, c.replace("_", " "), re.IGNORECASE
                         ):
                             self.errors.append(
-                                msg["validation_msg_invalid_regex_match"]
+                                msg["validation_msg_invalid_data"]
                                 % (c, header, str(cellcount + 1), regex_human_readable)
                             )
                             self.flag = False


### PR DESCRIPTION
Fix error message concatenation for regex validation.

# COPO Pull Request

## Title
<em>Fix KeyError: 'validation_msg_invalid_regex_match' error in optional_field_dtol_validators.py</em>

---

## Jira Link
<em>[paste jira link(s)](https://earlham-institute.atlassian.net/browse/CD-183?atlOrigin=eyJpIjoiNWIwOWQ4YjEwMjlkNDBlNzg5NTE2OGZkY2NkY2Y4NzgiLCJwIjoiaiJ9)</em>

<em>Correct error message in optional field validation</em>

---

## Summary of Changes
<em>The change prevents a key error from occurring and allows sample validation to proceed</em>

---

## Checklist Before Requesting Review

- [ ] Jira ticket is in the correct state  
- [ ] Change meets the acceptance criteria  
- [ ] Manual test plan has been followed and passed  
- [ ] No debug prints or experimental code left in  
- [ ] API or schema changes documented  

---

## Testing Evidence
<em>List tests passed from manual test plan</em>

---

## Reviewer Notes
<em>Highlight anything the reviewer should pay special attention to.  
Mention any technical debt you are aware of but not resolving here.</em>

---

## Review Responsibilities

- Developer pull requests: reviewed by Senior Developer  
- Senior Developer's pull requests: reviewed by Manager 
- Manager's pull requests: reviewed by Senior Developer

Confirm the correct reviewer is assigned.

---

## Deployment Notes
Note whether this change requires config updates, migrations, restarts, or downstream updates.

---

## After Approval

- Move the Jira ticket to the next state  

