### PR TITLE
CD-186: Add Dependabot and Docker release workflows with GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+# Create a bot to automatically pull requests
+version: 2
+
+updates:
+
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+    open-pull-requests-limit: 10
+
+    labels:
+      - "dependencies"
+      - "python"
+
+  # Dockerfile base image updates
+  - package-ecosystem: "docker"
+    directory: "/deployment/web/"
+    schedule:
+      interval: "weekly"
+
+    labels:
+      - "docker"
+
+  # GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+    labels:
+      - "github-actions"

--- a/.github/workflows/dependabot-checks.yml
+++ b/.github/workflows/dependabot-checks.yml
@@ -1,0 +1,35 @@
+# Run continuous integration (CI) checks on pull requests created 
+# by Dependabot and merged into the main branch.
+name: Dependabot validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  dependabot:
+    if: github.actor == 'dependabot[bot]'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements/base.txt
+
+      - name: Run Django tests
+        run: python manage.py test
+
+      # - name: Run Playwright tests
+      #   run: |
+      #     playwright install --with-deps
+      #     pytest test/playwright --headless
+
+      - name: Build Docker image (validation only)
+        run: docker build -t copo/copo-new-web:ci-test-${GITHUB_SHA} .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 # Release Docker images to Docker Hub when a new tag is pushed.
+# Note dev/demo Docker compose file uses 4 digits while production uses 3
 # e.g. git tag v1.0.0
 #      git push origin v1.0.0
 
@@ -14,13 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout project code
         uses: actions/checkout@v4
 
-      - name: Extract Docker image tag
-        id: vars
-        run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          echo "version=$TAG" >> $GITHUB_OUTPUT
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: copo/copo-new-web
+          tags: |
+            type=ref,event=tag
           
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -28,26 +32,43 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Docker image
-        run: |
-          docker build -t copo/copo-new-web:${{ steps.vars.outputs.version }} .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image locally for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deployment/web/Dockerfile
+          load: true
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=copo/copo-new-web:buildcache
+          cache-to: type=registry,ref=copo/copo-new-web:buildcache,mode=max
 
       - name: Run Docker Scout scan
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: copo/copo-new-web:${{ steps.vars.outputs.version }}
+          image: ${{ steps.meta.outputs.tags }}
           only-severities: critical,high
           exit-code: true
 
       - name: Run Trivy scan
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: copo/copo-new-web:${{ steps.vars.outputs.version }}
+          image-ref: ${{ steps.meta.outputs.tags }}
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
           
       - name: Push Docker image
-        run: |
-          docker push copo/copo-new-web:${{ steps.vars.outputs.version }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deployment/web/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=copo/copo-new-web:buildcache
+          cache-to: type=registry,ref=copo/copo-new-web:buildcache,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+# Release Docker images to Docker Hub when a new tag is pushed.
+# e.g. git tag v1.0.0
+#      git push origin v1.0.0
+
+name: Release Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+        uses: actions/checkout@v4
+
+      - name: Extract Docker image tag
+        id: vars
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+          
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t copo/copo-new-web:${{ steps.vars.outputs.version }} .
+
+      - name: Run Docker Scout scan
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: copo/copo-new-web:${{ steps.vars.outputs.version }}
+          only-severities: critical,high
+          exit-code: true
+
+      - name: Run Trivy scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: copo/copo-new-web:${{ steps.vars.outputs.version }}
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          
+      - name: Push Docker image
+        run: |
+          docker push copo/copo-new-web:${{ steps.vars.outputs.version }}


### PR DESCRIPTION
# COPO Pull Request

## Title
<em>Implement security improvements and CI Docker image builds</em>

---

## Jira Link
<em>https://earlham-institute.atlassian.net/browse/CD-186?atlOrigin=eyJpIjoiYTE4M2JiOThiYjJhNDMxN2I0NTI5NGI3OTNjZmRiMzciLCJwIjoiaiJ9</em>

<em>Implement Docker image security scanning and Dependabot auto-patching for improved security</em>

---

## Summary of Changes
<em>Enable Docker Scout and Trivy security scanning for Docker images built and pushed via GitHub Actions</em>
<em>Add Dependabot configuration for automated dependency updates and patching</em>

---

## Checklist Before Requesting Review

- [ ] Jira ticket is in the correct state  
- [ ] Change meets the acceptance criteria  
- [ ] Manual test plan has been followed and passed  
- [ ] No debug prints or experimental code left in  
- [ ] API or schema changes documented  

---

## Testing Evidence
<em>List tests passed from manual test plan</em>

---

## Reviewer Notes
<em>Docker Hub AutoBuilds option needs to be disabled  on Docker Hub</em>

<em>The options - Dependabot version updates, Dependabot alerts, Dependabot security updates, Dependency graph and Secret scanning need to be enabled under the "Security" or "Advanced Security" section on GitHub</em>

---

## Review Responsibilities

- Developer pull requests: reviewed by Senior Developer  
- Senior Developer's pull requests: reviewed by Manager 
- Manager's pull requests: reviewed by Senior Developer

Confirm the correct reviewer is assigned.

---

## Deployment Notes
Note whether this change requires config updates, migrations, restarts, or downstream updates.

---

## After Approval

- Move the Jira ticket to the next state  

