### PR TITLE
CD-134: Fix SyntaxWarning errors

### DIFF
--- a/common/ena_utils/ena_helper.py
+++ b/common/ena_utils/ena_helper.py
@@ -1116,7 +1116,7 @@ class EnaSubmissionHelper:
                     #by the validation step
                     self.logging_error("assembly submission failed: " + output)
                     return {"status": False, "message": output}
-                accession = re.search( "ERZ\d*\w" , output).group(0).strip()
+                accession = re.search(r"ERZ\d*\w" , output).group(0).strip()
                 assembly_accession = dict(
                     accession = accession,
                     alias = f'webin-{submission_type}-{row["study_id"]}_{row["assembly_id"]}_{row["assemblyname"]}',

--- a/common/validators/ena_validators/ena_checklist_validators.py
+++ b/common/validators/ena_validators/ena_checklist_validators.py
@@ -223,7 +223,7 @@ class TaxonValidator(Validator):
                     if any(x for x in scientific_name_list):
                         for scientific_name in scientific_name_list:
                             # Check if scientific name is a string
-                            if not re.match('^[A-Za-z\s]+$', scientific_name):
+                            if not re.match(r'^[A-Za-z\s]+$', scientific_name):
                                 matching_rows = self.data.index[
                                     self.data[key] == scientific_name
                                 ].tolist()

--- a/src/apps/copo_assembly_submission/utils/EnaAssembly.py
+++ b/src/apps/copo_assembly_submission/utils/EnaAssembly.py
@@ -341,7 +341,7 @@ def process_assembly_pending_submission():
                     #this may happen for instance if the same assembly has already been submitted, which would not get caught
                     #by the validation step
                     return {"error": output}
-                accession = re.search( "ERZ\d*\w" , output).group(0).strip()
+                accession = re.search(r"ERZ\d*\w" , output).group(0).strip()
                 Assembly().add_accession(id=assembly_id, accession=accession)
                 Submission().add_assembly_accession(sub["_id"], accession, "webin-genome-" + assembly["assemblyname"], assembly_id)
 

--- a/src/apps/copo_barcoding_submission/utils/EnaTaggedSequence.py
+++ b/src/apps/copo_barcoding_submission/utils/EnaTaggedSequence.py
@@ -877,7 +877,7 @@ class EnaTaggedSequence:
                 # by the validation step
                 return {"error": output}
 
-            accession = re.search("ERZ\d*\w", output).group(0).strip()
+            accession = re.search(r"ERZ\d*\w", output).group(0).strip()
             self._add_tagged_seq_accession(
                 ObjectId(submission_id),
                 accession,

--- a/src/apps/copo_sample/urls.py
+++ b/src/apps/copo_sample/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     re_path(r'^view/(?P<profile_id>[a-z0-9]+)/(?P<ui_component>\w+)', views.copo_samples,
             name='copo_samples'),
 
-    re_path("download_manifest/(?P<profile_id>[a-z0-9]+)/(?P<sample_checklist_id>[A-Za-z0-9\_]+)", views.download_manifest),
+    re_path(r"download_manifest/(?P<profile_id>[a-z0-9]+)/(?P<sample_checklist_id>[A-Za-z0-9\_]+)", views.download_manifest),
     path('parse_sample_spreadsheet/', views.parse_sample_spreadsheet,
          name="parse_sample_spreadsheet"),
     path('save_sample_records/', views.save_sample_records,

--- a/src/apps/copo_single_cell_submission/urls.py
+++ b/src/apps/copo_single_cell_submission/urls.py
@@ -5,17 +5,17 @@ app_name = 'copo_single cell_schemas'
 
 urlpatterns = [
 
-    re_path('parse_singlecell_spreadsheet/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/', views.parse_singlecell_spreadsheet,
+    re_path(r'parse_singlecell_spreadsheet/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/', views.parse_singlecell_spreadsheet,
          name="parse_singlecell_spreadsheet"),
-    re_path('save_singlecell_records/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/', views.save_singlecell_records,
+    re_path(r'save_singlecell_records/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/', views.save_singlecell_records,
          name="save_singlecell_records"),
 
-    re_path("download_manifest/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/(?P<study_id>[A-Za-z0-9]+)", views.download_manifest),
-    re_path("download_initial_manifest/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/(?P<checklist_id>\w+)", views.download_init_blank_manifest, name="download_initial_manifest"),
+    re_path(r"download_manifest/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/(?P<study_id>[A-Za-z0-9]+)", views.download_manifest),
+    re_path(r"download_initial_manifest/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/(?P<checklist_id>\w+)", views.download_init_blank_manifest, name="download_initial_manifest"),
 
-    re_path('view/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/(?P<ui_component>\w+)', views.copo_singlecell,
+    re_path(r'view/(?P<profile_id>[a-z0-9]+)/(?P<schema_name>\w+)/(?P<ui_component>\w+)', views.copo_singlecell,
          name='copo_singlecell'),
 
-    re_path('term/(?P<schema_name>\w+)/(?P<term>\w+)', views.display_term, name='display_term'),
+    re_path(r'term/(?P<schema_name>\w+)/(?P<term>\w+)', views.display_term, name='display_term'),
          
 ]


### PR DESCRIPTION
# COPO Pull Request

## Title
<em>Solve syntax warning errors about regex patterns</em>

---

## Jira Link
<em>https://earlham-institute.atlassian.net/browse/CD-134?atlOrigin=eyJpIjoiZDA0NTQ1NDc1OWU0NGFiYTgyZWI1OTM5ZjM5MjMwNzIiLCJwIjoiaiJ9</em>

<em>Raw strings should be used for regex patterns because they stop Python from treating backslashes as escapes, preventing warnings and ensuring the regex is interpreted correctly.</em>

---

## Summary of Changes
<em>'\s' and '\d' are not valid Python string escapes so  raw strings have to be used for regex patterns</em>

---

## Checklist Before Requesting Review

- [ ] Jira ticket is in the correct state  
- [ ] Change meets the acceptance criteria  
- [ ] Manual test plan has been followed and passed  
- [ ] No debug prints or experimental code left in  
- [ ] API or schema changes documented  

---

## Testing Evidence
><em>List tests passed from manual test plan</em>

---

## Reviewer Notes
><em>Highlight anything the reviewer should pay special attention to.  
Mention any technical debt you are aware of but not resolving here.</em>

---

## Review Responsibilities

- Developer pull requests: reviewed by Senior Developer  
- Senior Developer's pull requests: reviewed by Manager 
- Manager's pull requests: reviewed by Senior Developer

Confirm the correct reviewer is assigned.

---

## Deployment Notes
>Note whether this change requires config updates, migrations, restarts, or downstream updates.

---

## After Approval

- Move the Jira ticket to the next state  

