### PR TITLE
Fix local dev environment: ubuntu 24.04, VS Code venv interpreter, asgi path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,14 @@ updates:
     labels:
       - "docker"
 
+    ignore:
+      # The local dev images are deliberately pinned to the Ubuntu 24.04 LTS
+      # (Python 3.12, matching production). Newer Ubuntu releases ship newer
+      # Python (e.g. 26.04 -> 3.14) which breaks pinned C-extension deps such
+      # as gevent. Moving off 24.04 is a deliberate migration, not an
+      # automated bump, so ignore all ubuntu updates. See PR #115.
+      - dependency-name: "ubuntu"
+
   # GitHub Actions updates
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,10 @@
       "name": "Python: Django",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
-        "PYTHONPATH1": "${workspaceFolder}/lib:${PYTHONPATH}",
+        "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}",
         "GEVENT_SUPPORT": "True"
       },
       "args": ["runserver", "0.0.0.0:8000"],
@@ -21,9 +22,10 @@
       "name": "Python: Django Shell",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
-        "PYTHONPATH1": "${workspaceFolder}/lib:${PYTHONPATH}"
+        "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
       },
       "args": ["shell_plus", "--ptpython"],
       "django": true,
@@ -33,6 +35,7 @@
       "name": "Python: Django makemigration",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
@@ -44,6 +47,7 @@
     {
       "name": "Python: Celery Workers",
       "type": "debugpy",
+      "python": "/opt/venv/bin/python",
       "env": {
         "GEVENT_SUPPORT": "True"
       },
@@ -70,6 +74,7 @@
     {
       "name": "Python: Celery Workers file_transfers",
       "type": "debugpy",
+      "python": "/opt/venv/bin/python",
       "env": {
         "GEVENT_SUPPORT": "True"
       },
@@ -97,6 +102,7 @@
       "name": "Python: Celery Beat",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "module": "celery",
       "console": "integratedTerminal",
       "env": {
@@ -108,6 +114,7 @@
       "name": "Python: Generate standards map",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
@@ -120,6 +127,7 @@
       "name": "Python: Validate API enums",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
@@ -132,6 +140,7 @@
       "name": "Python: Handle Update Requests",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/shared_tools/scripts/copo_record/update_requests/handle_update_requests.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  // The container installs all dependencies into the venv at /opt/venv,
+  // not the system Python. Point VS Code at it so the debugger, IntelliSense
+  // and the integrated terminal all resolve the project's packages.
+  "python.defaultInterpreterPath": "/opt/venv/bin/python"
+}

--- a/deployment/web/Dockerfile_local_linux
+++ b/deployment/web/Dockerfile_local_linux
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM ubuntu:24.04
 
 ENV PYTHONUNBUFFERED=1
 
@@ -52,7 +52,7 @@ RUN curl -fsSL https://code-server.dev/install.sh | sh
 #RUN wget -q -O- https://aka.ms/install-vscode-server/setup.sh | sh
 
 # Note that since venv is installed at /opt/venv then, daphne is installed at /opt/venv/bin/daphne not /usr/local/bin/daphne
-#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 web.asgi:application"]
+#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 src.main_config.asgi:application"]
 
 #wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin &&
 

--- a/deployment/web/Dockerfile_local_mac
+++ b/deployment/web/Dockerfile_local_mac
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM ubuntu:24.04
 
 ENV PYTHONUNBUFFERED=1
 
@@ -52,6 +52,6 @@ ENV PATH="/root/.aspera/cli/bin:$PATH"
 #RUN curl -fsSL https://code-server.dev/install.sh | sh
 
 # Note that since venv is installed at /opt/venv then, daphne is installed at /opt/venv/bin/daphne not /usr/local/bin/daphne
-#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 web.asgi:application"]
+#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 src.main_config.asgi:application"]
 
 # wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin &&


### PR DESCRIPTION
## Why
Local Docker builds (`Dockerfile_local_mac` / `_linux`) broke after the dependabot bump of the base image **ubuntu 24.04 → 26.04** (#75). Ubuntu 26.04 ships **Python 3.14**, and the pinned `gevent==24.10.3` cannot compile there:

```
src/gevent/libev/corecext.pyx:69:26: undeclared name not builtin: long
```

CI didn't catch it because the smoke test builds the **production** `Dockerfile` (`python:3.12.7-slim-bookworm`), not the local ones.

## Changes
- **`Dockerfile_local_mac` / `Dockerfile_local_linux`**: revert base image `ubuntu:26.04 → ubuntu:24.04`. 24.04 ships Python 3.12, matching production, so all pinned deps build. (Full move to 3.14 is a separate effort — see open #109.)
- **`.vscode/launch.json` + `.vscode/settings.json`**: pin the debugpy configs and the default interpreter to `/opt/venv/bin/python`. Dependencies are installed into the container venv, not system Python, so the debugger failed with `ModuleNotFoundError: No module named 'django'`. Also fixes the `PYTHONPATH1` typo.
- **Stale comments**: correct the commented-out ENTRYPOINT in both local Dockerfiles, `web.asgi → src.main_config.asgi` (the package moved; prod/demo compose are already correct).

## Notes
- Demo and prod deployments were **not** affected — their daphne command already uses `src.main_config.asgi:application`.
- Verified locally: image builds on 24.04, daphne serves HTTP 200, VS Code debugger resolves the venv.