### PR TITLE
Fix WebSockets: pin redis-py to 5.x (redis 8 breaks Channels)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
       - "dependencies"
       - "python"
 
+    ignore:
+      # redis-py must stay on 5.x: redis-py 8 breaks Django Channels
+      # (channels-redis 4.1.0) — the channel-layer listener's blocking read
+      # times out after ~5s, closing every WebSocket with a 1011 and killing
+      # all live submission/validation feedback. Hold at 5.x (5.x patch/minor
+      # bumps are still allowed) until channels-redis supports redis-py 8.
+      - dependency-name: "redis"
+        update-types: ["version-update:semver-major"]
+
   # Dockerfile base image updates
   - package-ecosystem: "docker"
     directory: "/deployment/web/"

--- a/deployment/local.copo.compose.linux.yaml
+++ b/deployment/local.copo.compose.linux.yaml
@@ -8,7 +8,10 @@
 ## The .env file contains environment variables. Ensure that both the .env file and the 
 ## local.copo.compose.linux.yaml file are in the same directory before running the command below.
 #
-# $ export $(cat .env) > /dev/null 2>&1; docker compose -f local.copo.compose.linux.yaml up -d
+# $ docker compose --env-file .env -f local.copo.compose.linux.yaml up -d
+#   (use --env-file so Compose parses .env: it strips the quotes that protect
+#    values containing special characters, e.g. a WEBIN password with '&'.
+#    `export $(cat .env)` leaves those quotes inside the value and breaks them.)
 #
 ## Step #2  - Run Django management commands in the terminal 
 ## to set up the database and create a superuser (for a new deployment with empty DB only)

--- a/deployment/local.copo.compose.mac.yaml
+++ b/deployment/local.copo.compose.mac.yaml
@@ -8,7 +8,10 @@
 ## The .env file contains environment variables. Ensure that both the .env file and the 
 ## local.copo.compose.mac.yaml file are in the same directory before running the command below.
 #
-# $ export $(cat .env) > /dev/null 2>&1; docker compose -f local.copo.compose.mac.yaml up -d
+# $ docker compose --env-file .env -f local.copo.compose.mac.yaml up -d
+#   (use --env-file so Compose parses .env: it strips the quotes that protect
+#    values containing special characters, e.g. a WEBIN password with '&'.
+#    `export $(cat .env)` leaves those quotes inside the value and breaks them.)
 #
 ## Step #2  - Run Django management commands in the terminal 
 ## to set up the database and create a superuser (for a new deployment with empty DB only)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -165,7 +165,7 @@ pytz==2026.2
 #rauth==0.7.3
 #rcssmin==1.1.2
 #rdflib==7.1.4
-redis==8.0.0
+redis==5.0.8
 #rend==6.4.2
 requests==2.32.3
 requests-oauthlib==1.3.1


### PR DESCRIPTION
## Problem
After rebuilding the local image (which reinstalled `base.txt`), **all WebSockets** started closing with **code 1011** ~5s after connecting, killing every piece of live feedback (sample status, submission progress, manifest validation, file transfers).

Server-side traceback:
```
redis.exceptions.TimeoutError: Timeout reading from <redis>:6379
  channels/utils.py:57 await_many_dispatch -> await task
  redis/_parsers/hiredis.py read_from_socket
```

## Root cause
**`redis==8.0.0`** (bumped from 5.0.0 by Dependabot #88) is incompatible with **`channels-redis==4.1.0`**. The channel layer's listener holds a long blocking read waiting for messages; under redis-py 8 that read is aborted after ~5s, which Channels turns into a 1011 close.

Verified by reproducing the idle-receive timeout directly:

| channels-redis | redis-py | idle receive |
|---|---|---|
| 4.1.0 | 8.0.0 | ❌ Timeout @5s |
| 4.3.0 | 8.0.0 | ❌ Timeout @5s |
| 4.1.0 | **5.0.8** | ✅ survives |

Bumping channels-redis does **not** help — the incompatibility is on the redis-py side — so we hold redis-py at 5.x.

> ⚠️ This is a latent **production** bug: `main` pins redis 8, so prod/demo WebSockets break on the next image rebuild.

## Changes
- `requirements/base.txt`: `redis==8.0.0` → `redis==5.0.8`.
- `.github/dependabot.yml`: ignore **major** redis bumps (5.x patch/minor still allowed) so 8.x isn't re-proposed.
- Local compose templates: document `docker compose --env-file .env ...` instead of `export $(cat .env)`. The latter leaves the quotes that protect special characters inside the value (e.g. a WEBIN password containing `&`), which made ENA submission fail with **HTTP 403**.

## Validation
Reproduced the 1011 and the idle-receive timeout; confirmed `redis==5.0.8` keeps the channel-layer read open and WebSockets stay connected.