### PR TITLE
Fix local dev + WebSockets: ubuntu 24.04, venv interpreter, redis-py 5.x, .env launch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
       - "dependencies"
       - "python"
 
+    ignore:
+      # redis-py must stay on 5.x: redis-py 8 breaks Django Channels
+      # (channels-redis 4.1.0) — the channel-layer listener's blocking read
+      # times out after ~5s, closing every WebSocket with a 1011 and killing
+      # all live submission/validation feedback. Hold at 5.x (5.x patch/minor
+      # bumps are still allowed) until channels-redis supports redis-py 8.
+      - dependency-name: "redis"
+        update-types: ["version-update:semver-major"]
+
   # Dockerfile base image updates
   - package-ecosystem: "docker"
     directory: "/deployment/web/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,14 @@ updates:
     labels:
       - "docker"
 
+    ignore:
+      # The local dev images are deliberately pinned to the Ubuntu 24.04 LTS
+      # (Python 3.12, matching production). Newer Ubuntu releases ship newer
+      # Python (e.g. 26.04 -> 3.14) which breaks pinned C-extension deps such
+      # as gevent. Moving off 24.04 is a deliberate migration, not an
+      # automated bump, so ignore all ubuntu updates. See PR #115.
+      - dependency-name: "ubuntu"
+
   # GitHub Actions updates
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,10 @@
       "name": "Python: Django",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
-        "PYTHONPATH1": "${workspaceFolder}/lib:${PYTHONPATH}",
+        "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}",
         "GEVENT_SUPPORT": "True"
       },
       "args": ["runserver", "0.0.0.0:8000"],
@@ -21,9 +22,10 @@
       "name": "Python: Django Shell",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
-        "PYTHONPATH1": "${workspaceFolder}/lib:${PYTHONPATH}"
+        "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
       },
       "args": ["shell_plus", "--ptpython"],
       "django": true,
@@ -33,6 +35,7 @@
       "name": "Python: Django makemigration",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
@@ -44,6 +47,7 @@
     {
       "name": "Python: Celery Workers",
       "type": "debugpy",
+      "python": "/opt/venv/bin/python",
       "env": {
         "GEVENT_SUPPORT": "True"
       },
@@ -70,6 +74,7 @@
     {
       "name": "Python: Celery Workers file_transfers",
       "type": "debugpy",
+      "python": "/opt/venv/bin/python",
       "env": {
         "GEVENT_SUPPORT": "True"
       },
@@ -97,6 +102,7 @@
       "name": "Python: Celery Beat",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "module": "celery",
       "console": "integratedTerminal",
       "env": {
@@ -108,6 +114,7 @@
       "name": "Python: Generate standards map",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
@@ -120,6 +127,7 @@
       "name": "Python: Validate API enums",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/manage.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
@@ -132,6 +140,7 @@
       "name": "Python: Handle Update Requests",
       "type": "debugpy",
       "request": "launch",
+      "python": "/opt/venv/bin/python",
       "program": "${workspaceFolder}/shared_tools/scripts/copo_record/update_requests/handle_update_requests.py",
       "env": {
         "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  // The container installs all dependencies into the venv at /opt/venv,
+  // not the system Python. Point VS Code at it so the debugger, IntelliSense
+  // and the integrated terminal all resolve the project's packages.
+  "python.defaultInterpreterPath": "/opt/venv/bin/python"
+}

--- a/deployment/local.copo.compose.linux.yaml
+++ b/deployment/local.copo.compose.linux.yaml
@@ -8,7 +8,10 @@
 ## The .env file contains environment variables. Ensure that both the .env file and the 
 ## local.copo.compose.linux.yaml file are in the same directory before running the command below.
 #
-# $ export $(cat .env) > /dev/null 2>&1; docker compose -f local.copo.compose.linux.yaml up -d
+# $ docker compose --env-file .env -f local.copo.compose.linux.yaml up -d
+#   (use --env-file so Compose parses .env: it strips the quotes that protect
+#    values containing special characters, e.g. a WEBIN password with '&'.
+#    `export $(cat .env)` leaves those quotes inside the value and breaks them.)
 #
 ## Step #2  - Run Django management commands in the terminal 
 ## to set up the database and create a superuser (for a new deployment with empty DB only)

--- a/deployment/local.copo.compose.mac.yaml
+++ b/deployment/local.copo.compose.mac.yaml
@@ -8,7 +8,10 @@
 ## The .env file contains environment variables. Ensure that both the .env file and the 
 ## local.copo.compose.mac.yaml file are in the same directory before running the command below.
 #
-# $ export $(cat .env) > /dev/null 2>&1; docker compose -f local.copo.compose.mac.yaml up -d
+# $ docker compose --env-file .env -f local.copo.compose.mac.yaml up -d
+#   (use --env-file so Compose parses .env: it strips the quotes that protect
+#    values containing special characters, e.g. a WEBIN password with '&'.
+#    `export $(cat .env)` leaves those quotes inside the value and breaks them.)
 #
 ## Step #2  - Run Django management commands in the terminal 
 ## to set up the database and create a superuser (for a new deployment with empty DB only)

--- a/deployment/web/Dockerfile_local_linux
+++ b/deployment/web/Dockerfile_local_linux
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM ubuntu:24.04
 
 ENV PYTHONUNBUFFERED=1
 
@@ -52,7 +52,7 @@ RUN curl -fsSL https://code-server.dev/install.sh | sh
 #RUN wget -q -O- https://aka.ms/install-vscode-server/setup.sh | sh
 
 # Note that since venv is installed at /opt/venv then, daphne is installed at /opt/venv/bin/daphne not /usr/local/bin/daphne
-#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 web.asgi:application"]
+#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 src.main_config.asgi:application"]
 
 #wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin &&
 

--- a/deployment/web/Dockerfile_local_mac
+++ b/deployment/web/Dockerfile_local_mac
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM ubuntu:24.04
 
 ENV PYTHONUNBUFFERED=1
 
@@ -52,6 +52,6 @@ ENV PATH="/root/.aspera/cli/bin:$PATH"
 #RUN curl -fsSL https://code-server.dev/install.sh | sh
 
 # Note that since venv is installed at /opt/venv then, daphne is installed at /opt/venv/bin/daphne not /usr/local/bin/daphne
-#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 web.asgi:application"]
+#ENTRYPOINT ["bash","-c","rsync -avhW --no-compress --progress /code/ /copo/ &&  rm -rf /code/ && python manage.py migrate && python manage.py social_accounts && python manage.py setup_groups && python manage.py setup_schemas && python manage.py createcachetable && supervisord -c celery.conf && supervisorctl -c celery.conf start all && /opt/venv/bin/daphne -b 0.0.0.0 -p 8000 src.main_config.asgi:application"]
 
 # wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin &&

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -165,7 +165,7 @@ pytz==2026.2
 #rauth==0.7.3
 #rcssmin==1.1.2
 #rdflib==7.1.4
-redis==8.0.0
+redis==5.0.8
 #rend==6.4.2
 requests==2.32.3
 requests-oauthlib==1.3.1


### PR DESCRIPTION
Consolidates the local-dev and WebSocket fixes into one PR (supersedes the two split PRs).

## 1. Local image build broke (Python 3.14 / gevent)
The `ubuntu 24.04 → 26.04` bump (#75) pushed the local images to Python 3.14, where pinned `gevent==24.10.3` fails to compile.
- `Dockerfile_local_mac` / `_linux`: `ubuntu:26.04 → ubuntu:24.04` (Python 3.12, matches prod `python:3.12.7-slim-bookworm`).
- `dependabot.yml`: ignore `ubuntu` bumps (deliberate LTS pin).

## 2. VS Code debugger couldn't find dependencies
Deps live in the container venv (`/opt/venv`), not system Python.
- `.vscode/launch.json` + new `.vscode/settings.json`: pin interpreter to `/opt/venv/bin/python`; fix `PYTHONPATH1` typo.
- Correct stale `web.asgi → src.main_config.asgi` comment in the local Dockerfiles (demo/prod compose were already correct).

## 3. WebSockets closed with 1011 / no live feedback (prod bug)
`redis==8.0.0` (#88) is incompatible with `channels-redis==4.1.0`: the channel-layer listener's blocking read times out after ~5s, closing every socket with a 1011 and killing all submission/validation feedback. Confirmed by reproducing the idle-receive timeout; reverting redis-py fixes it (bumping channels-redis does not).
- `requirements/base.txt`: `redis==8.0.0 → 5.0.8`.
- `dependabot.yml`: ignore major `redis` bumps.

## 4. ENA submission returned HTTP 403
`export $(cat .env)` leaves the quotes (that protect special chars like `&` in the WEBIN password) inside the value, so ENA auth was sent a quoted password.
- Local compose templates now document `docker compose --env-file .env ...`.

## Validation
Image builds on 24.04; daphne serves 200; channel-layer idle receive survives with redis 5.0.8; Compose `--env-file` resolves the password unquoted.