### PR TITLE
Fix ENA file-transfer race: claim pending transfers atomically

### DIFF
--- a/common/dal/copo_da.py
+++ b/common/dal/copo_da.py
@@ -861,6 +861,24 @@ class EnaFileTransfer(DAComponent):
             {"$set": {"status": "processing", "last_checked": helpers.get_datetime()}},
         )
 
+    def claim_pending_transfer(self, tx_id):
+        """Atomically claim a single transfer record by flipping it from
+        'pending' to 'processing'. The status condition is part of the same
+        update, so only one concurrent caller can win the claim; others get
+        None back and should skip the record.
+
+        This replaces the old read-then-set_processing pattern, which had a
+        race under gevent concurrency: the beat task fires every 10s while a
+        transfer is still running, and the mongo read in get_pending_transfers
+        is a gevent yield point, so two greenlets could read the same record as
+        'pending' before either marked it 'processing' and both upload it.
+        """
+        return self.get_collection_handle().find_one_and_update(
+            {"_id": ObjectId(tx_id), "status": "pending"},
+            {"$set": {"status": "processing", "last_checked": helpers.get_datetime()}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+
     def set_pending(self, tx_id):
         self.get_collection_handle().update_one(
             {"_id": ObjectId(tx_id)},

--- a/common/ena_utils/FileTransferUtils.py
+++ b/common/ena_utils/FileTransferUtils.py
@@ -243,12 +243,22 @@ def process_pending_file_transfers():
     # 4 check for md5
     # 5 transfer to ENA
     if docs:
-        # cast cursor to list for double iteration
-        # docs = list(docs)
-        # first iterate all transfer records and set to processing so celery won't pick them again and send for processing as this
-        # can lead to circular operations which won't terminate
-        tx_ids = [tx["_id"] for tx in docs]
-        EnaFileTransfer().set_processing(tx_ids)
+        # Atomically claim each candidate (pending -> processing) so a
+        # concurrent beat tick / gevent greenlet can't pick up the same record
+        # and upload the same file twice. Each claim is a single match-and-set,
+        # so only the winner gets the doc back; losers get None and are skipped.
+        # (Replaces the old bulk read-then-set_processing, which raced.)
+        eft = EnaFileTransfer()
+        claimed = []
+        for tx in docs:
+            won = eft.claim_pending_transfer(tx["_id"])
+            if won is not None:
+                claimed.append(won)
+            else:
+                log.debug(
+                    f"Transfer {tx.get('_id')} already claimed by another worker; skipping"
+                )
+        docs = claimed
 
         for tx in docs:
             try:


### PR DESCRIPTION
## Problem
The same data file is uploaded to ENA **twice concurrently**. Symptom: the `[FTP] <file>: N%` progress oscillates (`6,5,6,5,…,100`) instead of climbing — two uploads of the same file, each tracking its own progress.

## Cause
`process_pending_file_transfers` (runs on the `file_transfers` queue under `-P gevent`) is fired by Celery beat **every 10s**, but a transfer takes far longer. It claimed files in two non-atomic steps:

```python
docs = EnaFileTransfer().get_pending_transfers()   # READ  (mongo I/O = gevent yield point)
EnaFileTransfer().set_processing([d["_id"] ...])    # WRITE (mark processing)
```

During the mongo read, gevent yields to the next beat tick's greenlet, which reads the same record as still `"pending"` (the first hasn't marked it yet). Both then claim and upload it.

## Fix
Replace the bulk read-then-mark with a **per-record atomic claim**:

```python
def claim_pending_transfer(self, tx_id):
    return self.get_collection_handle().find_one_and_update(
        {"_id": ObjectId(tx_id), "status": "pending"},
        {"$set": {"status": "processing", "last_checked": helpers.get_datetime()}},
        return_document=pymongo.ReturnDocument.AFTER,
    )
```

The status condition is part of the same update, so only one caller can win each record; losers get `None` and skip it. The worker now transfers only the records it actually claimed. `get_pending_transfers` is unchanged (still produces the candidate list); the atomic claim is what prevents the double-pickup.

## Notes
- Behaviour is otherwise identical — transfers that completed before still complete; they just no longer run twice.
- Both files compile clean. Affects the submission pipeline (prod + demo), so worth a careful review.