### PR TITLE
CD-196: Fix carousel background images hidden by CSS background shorthand

### DIFF
--- a/static/copo/css/copo_modern_scheme.css
+++ b/static/copo/css/copo_modern_scheme.css
@@ -58,7 +58,7 @@
    ══════════════════════════════════════════ */
 body {
   font-family: var(--co-font) !important;
-  background: var(--co-bg) !important;
+  background-color: var(--co-bg) !important;
   color: var(--co-text) !important;
   -webkit-font-smoothing: antialiased !important;
 }


### PR DESCRIPTION
## Summary
- `copo_modern_scheme.css` used `background: var(--co-bg) !important` on `body`
- The CSS `background` shorthand resets all sub-properties including `background-image: none`, overriding the JS-set inline style in `landing.js`
- Fix: change to `background-color: var(--co-bg) !important` so only the colour is set without wiping the image

## Test plan
- [ ] Visit `http://127.0.0.1:8000/` and confirm a nature photo background image is visible behind the Submit Data / Try Demo buttons
- [ ] Hard-refresh to verify no caching artefacts
- [ ] Check dark mode still applies correct background colour