### PR TITLE
CD-199: Increase minimum profile title length from 10 to 20 characters

### DIFF
--- a/common/lookup/lookup.py
+++ b/common/lookup/lookup.py
@@ -4,7 +4,7 @@ import os
 from .resolver import RESOLVER
 
 # Minimum field lengths enforced at manifest upload time and during ENA submission.
-PROFILE_TITLE_MIN_LENGTH = 10
+PROFILE_TITLE_MIN_LENGTH = 20
 PROFILE_DESCRIPTION_MIN_LENGTH = 20
 
 # •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••#


### PR DESCRIPTION
## Summary
- Bumps `PROFILE_TITLE_MIN_LENGTH` from `10` to `20` in `common/lookup/lookup.py`
- ENA rejects submissions when a profile title is less than 20 characters — the old limit of 10 allowed titles that would fail at submission time with: `string length (19) is less than minLength facet (20) for type of TITLE element in ProjectType`

## Test plan
- [ ] Attempt to create a profile with a title under 20 characters — should be rejected with a clear error message
- [ ] Create a profile with a title of exactly 20 characters — should succeed