### PR TITLE
Disable CircleCI E2E suite until it is restored

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,3 +102,4 @@ workflows:
             branches:
               ignore:
                 - /^dependabot\/.*/
+                - /.*/ # E2E suite is currently out of date; disabled until restored


### PR DESCRIPTION
## Summary

- Adds a catch-all `/.*/` branch ignore filter to the CircleCI workflow so the Puppeteer E2E suite never triggers
- The suite has been out of date for some time and was failing on every branch, producing a permanent red badge on all PRs
- The job definition, test scripts, and docker-compose infra are all left intact — re-enabling is a one-line revert

## Test plan

- [ ] Confirm no CircleCI build is triggered after merge
- [ ] Verify existing PRs (#107 etc.) no longer show a CircleCI status check going forward