### PR TITLE
Remove unused deps (pronto, chardet) and certifi pin to unblock Dependabot

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,11 +24,9 @@ botocore==1.43.39
 Brotli==1.2.0
 bs4==0.0.1
 celery==5.6.3
-certifi==2024.7.4
 #cffi==1.16.0
 channels==4.3.2
 channels-redis==4.3.0
-chardet==5.1.0
 #colorama==0.4.1
 #colored==1.4.3
 #configparser==3.7.4
@@ -135,7 +133,6 @@ ply==3.9
 progressbar2==3.34.3
 #prometheus-client==0.7.1
 prompt-toolkit==3.0.52
-pronto==2.7.3
 psycopg==3.3.4
 psycopg-binary==3.3.4
 ptpython==3.0.32


### PR DESCRIPTION
## What

Removes two unused packages and one over-restrictive pin from `requirements/base.txt`:

- **`pronto`** — top-level requirement with **zero references anywhere in the repo** (no imports, no config); depended on by nothing. Removed.
- **`chardet`** — required *only* by `pronto`. Orphaned once `pronto` is gone, so removed too.
- **`certifi==2024.7.4` pin** — `certifi` is a transitive dependency of `requests` and `selenium` so the package stays, but the explicit pin is dropped.

## Why

These unblock the two failing open Dependabot group PRs:

- **#179 (all-others)** was failing because it bumps `chardet` to 7.4.3 while `pronto 2.7.3` requires `chardet~=5.0`. Removing pronto/chardet eliminates the constraint.
- **#176 (testing)** was failing because it bumps `selenium` to 4.45.0 (`certifi>=2026.2.25`) while `base.txt` pinned `certifi==2024.7.4`. Removing the pin lets pip resolve a compatible certifi.

Verified against the running container with `pip show ... Required-by`: `certifi` → `requests, selenium`; `chardet` → `pronto`; `pronto` → (nothing).