### PR TITLE
Add setup_all bootstrap command and VS Code run option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,20 @@
       "justMyCode": false
     },
     {
+      "name": "Python: Setup All",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "/opt/venv/bin/python",
+      "program": "${workspaceFolder}/manage.py",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/lib:${PYTHONPATH}"
+      },
+      "args": ["setup_all"],
+      "console": "integratedTerminal",
+      "django": true,
+      "justMyCode": false
+    },
+    {
       "name": "Python: Django Shell",
       "type": "debugpy",
       "request": "launch",

--- a/src/apps/copo_core/management/commands/setup_all.py
+++ b/src/apps/copo_core/management/commands/setup_all.py
@@ -1,0 +1,53 @@
+# Runs the full local COPO bootstrap sequence in one go.
+# Mirrors the "Run Django/COPO setup functions" block of
+# shared_tools/scripts/setup/postgresqlDB_setup.sh, but as a single Django
+# management command so it can be launched from VS Code ("Python: Setup All").
+
+from django.core.management import BaseCommand, call_command
+
+
+# Commands that must succeed for the bootstrap to be meaningful. If one of these
+# fails the whole run aborts; any other (seed) step logs its error and continues,
+# so re-running on an already-seeded DB (e.g. superuser already exists) is safe.
+CRITICAL = {"makemigrations", "migrate"}
+
+# Ordered bootstrap steps: (human-readable label, command name, positional args).
+# Order matters — migrations must be applied before any seed command runs.
+STEPS = [
+    ("Make migrations", "makemigrations", []),
+    ("Make allauth migrations", "makemigrations", ["allauth"]),
+    ("Apply migrations", "migrate", []),
+    ("Set up groups", "setup_groups", []),
+    ("Set up schemas", "setup_schemas", []),
+    ("Create cache table", "createcachetable", []),
+    ("Configure social accounts", "social_accounts", []),
+    ("Set up sequencing centres", "setup_sequencing_centres", []),
+    ("Set up associated profile types", "setup_associated_profile_types", []),
+    ("Set up profile types", "setup_profile_types", []),
+    ("Set up news", "setup_news", []),
+    ("Create superuser", "createsuperuser", []),  # interactive — prompts on stdin
+]
+
+
+# The class must be named Command, and subclass BaseCommand
+class Command(BaseCommand):
+    help = "Run the full local COPO bootstrap (migrations + all setup_* seed commands) in one go."
+
+    def handle(self, *args, **options):
+        total = len(STEPS)
+        for index, (label, command_name, command_args) in enumerate(STEPS, start=1):
+            self.stdout.write(self.style.MIGRATE_HEADING(
+                f"\n[{index}/{total}] {label}  (manage.py {command_name} {' '.join(command_args)})".rstrip()
+            ))
+            self._run_step(label, command_name, command_args)
+
+    def _run_step(self, label, command_name, command_args):
+        try:
+            call_command(command_name, *command_args)
+        except Exception as error:
+            if command_name in CRITICAL:
+                self.stderr.write(self.style.ERROR(f"✗ {label} failed (critical): {error}"))
+                raise
+            self.stderr.write(self.style.WARNING(f"⚠ {label} skipped: {error}"))
+            return
+        self.stdout.write(self.style.SUCCESS(f"✓ {label}"))

--- a/src/apps/copo_core/management/commands/setup_all.py
+++ b/src/apps/copo_core/management/commands/setup_all.py
@@ -3,6 +3,7 @@
 # shared_tools/scripts/setup/postgresqlDB_setup.sh, but as a single Django
 # management command so it can be launched from VS Code ("Python: Setup All").
 
+from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand, call_command
 
 
@@ -39,7 +40,14 @@ class Command(BaseCommand):
             self.stdout.write(self.style.MIGRATE_HEADING(
                 f"\n[{index}/{total}] {label}  (manage.py {command_name} {' '.join(command_args)})".rstrip()
             ))
+            if command_name == "createsuperuser" and self._superuser_exists():
+                self.stdout.write(self.style.WARNING("⚠ Create superuser skipped: a superuser already exists"))
+                continue
             self._run_step(label, command_name, command_args)
+
+    @staticmethod
+    def _superuser_exists():
+        return get_user_model().objects.filter(is_superuser=True).exists()
 
     def _run_step(self, label, command_name, command_args):
         try:


### PR DESCRIPTION
## What

Adds a single `setup_all` Django management command that runs the full local COPO bootstrap in one ordered pass, plus a **"Python: Setup All"** entry in `.vscode/launch.json` so it can be launched from VS Code's Run and Debug dropdown (next to "Start All").

## Why

The local bootstrap steps currently live as a manual list in `shared_tools/scripts/setup/postgresqlDB_setup.sh` that has to be run by hand, command by command. This packages the same sequence as one runnable command.

## The sequence (mirrors the existing script)

`makemigrations` → `makemigrations allauth` → `migrate` → `setup_groups` → `setup_schemas` → `createcachetable` → `social_accounts` → `setup_sequencing_centres` → `setup_associated_profile_types` → `setup_profile_types` → `setup_news` → `createsuperuser`

## Failure policy

Migrations (`makemigrations`, `migrate`) are treated as **critical** — the run aborts if they fail. Every seed step **logs and continues**, so re-running on an already-seeded DB (e.g. the `admin` superuser already exists) reports a warning rather than crashing. This makes the command double as an idempotent 'top up my dev DB' tool.

## How to run

- VS Code → Run and Debug → **Python: Setup All** (uses `integratedTerminal` so the interactive `createsuperuser` prompt works), or
- `python manage.py setup_all` from inside the `copo_web` container.

## Verification

- `py_compile` clean; `manage.py help setup_all` resolves inside the running container (command is registered and imports cleanly). The bootstrap sequence itself was not executed against a DB as part of this change.