### PR TITLE
Fix pandas 3 breakages in shared spreadsheet and submission code

### DIFF
--- a/common/dal/copo_da.py
+++ b/common/dal/copo_da.py
@@ -599,9 +599,7 @@ class CGCore(DAComponent):
                 schema=schema_fields, type_name=referenced_type
             )
             columns = list(schema_df.columns)
-
-            for col in columns:
-                schema_df[col].fillna('n/a', inplace=True)
+            schema_df = schema_df.astype(object).fillna('n/a')
 
             schema_fields = schema_df.sort_values(by=['field_constraint_rank']).to_dict(
                 'records'
@@ -1436,7 +1434,7 @@ class EnaChecklist(DAComponent):
                     | (df["shown_when_no_sample"].isnull())
                 ]
             # df.set_index("name", drop=False, inplace=True)
-            df.fillna("", inplace=True)
+            df = df.astype(object).fillna("")
             checklist["fields"] = df.to_dict('index')
             return checklist
 

--- a/common/ena_utils/EnaChecklistHandler.py
+++ b/common/ena_utils/EnaChecklistHandler.py
@@ -708,7 +708,7 @@ def write_manifest(checklist, for_dtol=False, with_read=True, with_sample=True, 
         sample_df = pd.DataFrame.from_records(samples)
         new_column_name = { key : field["label" ]+ (" (optional)" if  field["mandatory"] != 'mandatory' else "") for key, field in checklist["fields"].items() }
         sample_df.rename(columns=new_column_name, inplace=True)
-        sample_df.drop(columns=sample_df.columns.difference(df1.columns), axis=1, inplace=True)
+        sample_df.drop(columns=sample_df.columns.difference(df1.columns), inplace=True)
 
         #sample_df = sample_df.rename(columns={"name": "Sample"})
         df1 = pd.concat([df1, sample_df], axis=0, join="outer")

--- a/common/ena_utils/ena_helper.py
+++ b/common/ena_utils/ena_helper.py
@@ -1539,8 +1539,7 @@ class SubmissionHelper:
         df_columns = df_attributes_df.columns
 
         # replace null values
-        for k in df_columns:
-            df_attributes_df[k].fillna('', inplace=True)
+        df_attributes_df = df_attributes_df.astype(object).fillna('')
 
         if 'study_samples' in df_columns:
             df_attributes_df['study_samples'] = df_attributes_df['study_samples'].apply(

--- a/src/apps/api/views/manifest_view.py
+++ b/src/apps/api/views/manifest_view.py
@@ -1024,7 +1024,6 @@ def generate_manifest_template(manifest_type, manifest_template_path, initial_da
         columns=initial_data.columns.difference(
             metadataEntry_worksheet_dataframe.columns
         ),
-        axis=1,
         inplace=True,
     )
     metadataEntry_worksheet_concatenation = pd.concat(

--- a/src/apps/copo_read_submission/utils/ena_read_submission.py
+++ b/src/apps/copo_read_submission/utils/ena_read_submission.py
@@ -1215,8 +1215,7 @@ class EnaReads:
 
         # set default for nans
         datafile_columns = datafiles_df.columns
-        for k in datafile_columns:
-            datafiles_df[k].fillna('', inplace=True)
+        datafiles_df = datafiles_df.astype(object).fillna('')
 
         # get run accessions - to provide info on datafiles submission status
         run_accessions = self.submission_helper.get_run_accessions()

--- a/src/apps/copo_single_cell_submission/utils/SingleCellSchemasHandler.py
+++ b/src/apps/copo_single_cell_submission/utils/SingleCellSchemasHandler.py
@@ -231,7 +231,7 @@ class SingleCellSchemasHandler:
                         if component_schema_df.empty:
                             continue
 
-                        component_schema_df.fillna("", inplace=True)
+                        component_schema_df = component_schema_df.astype(object).fillna("")
                         component_schema_df["choice"] = component_schema_df[
                             component_schema_df["term_type"] == "enum"
                         ]["term_name"].apply(
@@ -298,7 +298,7 @@ class SingleCellSchemasHandler:
                                     [component_schema_df_transposed, component_data_df],
                                     axis=0,
                                 )
-                                component_schema_df_transposed.fillna("", inplace=True)
+                                component_schema_df_transposed = component_schema_df_transposed.astype(object).fillna("")
 
                         # sheet_name = component_names.get(component_name, {}).get("name", component_name)
                         # sheet_name = sheet_name[:31]
@@ -523,7 +523,7 @@ class SingleCellSchemasHandler:
                             pd.isna(component_schema_df[schema_checklist])
                         ].index
                     )
-                    component_schema_df.fillna("", inplace=True)
+                    component_schema_df = component_schema_df.astype(object).fillna("")
 
                     if component_schema_df.empty:
                         continue
@@ -573,7 +573,7 @@ class SingleCellSchemasHandler:
                             component_data_df.rename(
                                 columns=new_column_name, inplace=True
                             )
-                            component_data_df.fillna("", inplace=True)
+                            component_data_df = component_data_df.astype(object).fillna("")
                             component_data_df["@type"] = url_prefix + reverse(
                                 "copo_single_cell_submission:display_term",
                                 args=[singlecell_schema["name"], component_name],
@@ -650,7 +650,7 @@ class SingleCellSchemasHandler:
                 )
                 if component_schema_df.empty:
                     continue
-                component_schema_df.fillna("", inplace=True)
+                component_schema_df = component_schema_df.astype(object).fillna("")
                 file_path = os.path.join(
                     settings.MANIFEST_PATH,
                     settings.MANIFEST_JSONLD_FILE_NAME.format(
@@ -778,7 +778,7 @@ class SinglecellschemasSpreadsheet:
                 schema_file_df = schema_file_df.merge(
                     schema_file_checksum_df, on="term_name", how="left"
                 )
-                schema_file_df.fillna("", inplace=True)
+                schema_file_df = schema_file_df.astype(object).fillna("")
             else:
                 schema_file_df["term_checksum"] = ""
 
@@ -875,7 +875,7 @@ class SinglecellschemasSpreadsheet:
                     # remove the rows with all empty values or 0
                     df = df.replace("", np.nan)
                     df.dropna(how="all", inplace=True)
-                    df.fillna("", inplace=True)
+                    df = df.astype(object).fillna("")
                     self.data[key] = df
 
                 singlecell = (
@@ -909,7 +909,7 @@ class SinglecellschemasSpreadsheet:
                         if component_schema_df.empty:
                             self.schemas.pop(component, None)
                             continue
-                        component_schema_df.fillna("", inplace=True)
+                        component_schema_df = component_schema_df.astype(object).fillna("")
                         component_schema_df["choice"] = component_schema_df[
                             component_schema_df["term_type"] == "enum"
                         ]["term_name"].apply(lambda x: singlecell["enums"].get(x, []))

--- a/src/apps/copo_single_cell_submission/utils/copo_single_cell.py
+++ b/src/apps/copo_single_cell_submission/utils/copo_single_cell.py
@@ -230,7 +230,7 @@ def generate_singlecell_record(profile_id, checklist_id=str(), study_id=str(), s
             # Generate unique DataTable row IDs: "componentName_studyId_identifier"
             component_data_df["DT_RowId"] = component_name + "_"+ study_id + "_" + component_data_df.get(identifier_map.get(component_name,""), "")
             component_data_df["record_id"] = component_data_df["DT_RowId"]
-            component_data_df.fillna("", inplace=True)
+            component_data_df = component_data_df.astype(object).fillna("")
 
             # Build the file_status column by concatenating "filename : transferStatus" for each file field
             file_terms = file_df_map.get(component_name, [])

--- a/src/apps/copo_single_cell_submission/utils/da.py
+++ b/src/apps/copo_single_cell_submission/utils/da.py
@@ -53,7 +53,7 @@ class SinglecellSchemas(DAComponent):
             component_df.drop(not_repository_columns, axis=1, inplace=True)
             component_df.dropna(how="all", inplace=True)
             component_df.rename(columns=lambda x: x.replace("repository_", ""), inplace=True)
-            component_df.fillna("", inplace=True)
+            component_df = component_df.astype(object).fillna("")
             return component_df
 
     def get_term_mapping(self, schema_name):

--- a/src/apps/copo_single_cell_submission/utils/ena_submission.py
+++ b/src/apps/copo_single_cell_submission/utils/ena_submission.py
@@ -105,7 +105,7 @@ def process_pending_submission_ena():
                 study_component_schema = schemas.get("study", {})
                 rename_columns = {field["term_name"]: term_mapping[field["copo_name"]].get("ENA",field["term_name"]) for field in study_component_schema if field["copo_name"] and field["copo_name"] in term_mapping}
                 study_component_df = pd.DataFrame.from_records(studies)
-                study_component_df.fillna(value="", inplace=True)
+                study_component_df = study_component_df.astype(object).fillna("")
                 study_component_df.rename(columns=rename_columns, inplace=True)
                 study = study_component_df.to_dict('records')[0]
 
@@ -187,11 +187,11 @@ def _prepare_analysis_submission(singlecell, component_name="sequencing_annotati
 
     analysis_component_schema = schemas[component_name]
     analysis_component_schema_df = pd.DataFrame.from_records(analysis_component_schema)
-    analysis_component_schema_df.fillna(value="", inplace=True)
+    analysis_component_schema_df = analysis_component_schema_df.astype(object).fillna("")
 
     schema_columns = analysis_component_data_df.columns[analysis_component_data_df.columns.isin(analysis_component_schema_df["term_name"].tolist() + ["accession_ena"])]
     rename_columns = {field["term_name"]: term_mapping[field["copo_name"]].get("ENA",field["term_name"]) for field in analysis_component_schema if field["copo_name"] and field["copo_name"] in term_mapping}
-    analysis_component_data_df.fillna(value="", inplace=True)
+    analysis_component_data_df = analysis_component_data_df.astype(object).fillna("")
     analysis_component_data_df = analysis_component_data_df[schema_columns]
     analysis_component_data_df.rename(columns=rename_columns, inplace=True)
     child_component_data_df_map = dict()
@@ -205,7 +205,7 @@ def _prepare_analysis_submission(singlecell, component_name="sequencing_annotati
     
     sample_component_data = components.get("sample", [])
     sample_component_data_df = pd.DataFrame.from_records(sample_component_data)
-    sample_component_data_df.fillna(value="", inplace=True)
+    sample_component_data_df = sample_component_data_df.astype(object).fillna("")
     sample_component_data_df = sample_component_data_df[[identifier_map["sample"], "biosampleAccession"]]
     analysis_component_data_df = analysis_component_data_df.merge(sample_component_data_df, left_on=parent_map[component_name]["sample"], right_on=identifier_map["sample"], how="left") 
     analysis_component_data_df["study_accession"] = study_accession
@@ -220,11 +220,11 @@ def _prepare_analysis_submission(singlecell, component_name="sequencing_annotati
             Logger().error(f"Missing schema for component {component} in singlecell submission: {singlecell.get('study_id', 'Unknown')}")
             continue
         child_component_schema_df = pd.DataFrame.from_records(child_component_schema)
-        child_component_schema_df.fillna(value="", inplace=True)
+        child_component_schema_df = child_component_schema_df.astype(object).fillna("")
         child_component_data_df = pd.DataFrame.from_records(child_component_data)
         schema_columns = child_component_data_df.columns[child_component_data_df.columns.isin(child_component_schema_df["term_name"].tolist())]
         rename_columns = {field["term_name"]: term_mapping[field["copo_name"]].get("ENA",field["term_name"]) for field in analysis_component_schema if field["copo_name"] and field["copo_name"] in term_mapping}
-        child_component_data_df.fillna(value="", inplace=True)
+        child_component_data_df = child_component_data_df.astype(object).fillna("")
         child_component_data_df = child_component_data_df[schema_columns]
         child_component_data_df.rename(columns=rename_columns, inplace=True)
         if component not in [f"{component_name}_run_ref", f"{component_name}_file"]:
@@ -284,11 +284,11 @@ def _prepare_assembly_submission(singlecell, component_name="assembly"):
     assembly_component_data_df = assembly_component_data_df.drop(assembly_component_data_df[assembly_component_data_df["accession_ena"]!=""].index)
     assembly_component_schema = schemas[component_name]
     assembly_component_schema_df = pd.DataFrame.from_records(assembly_component_schema)
-    assembly_component_schema_df.fillna(value="", inplace=True)
+    assembly_component_schema_df = assembly_component_schema_df.astype(object).fillna("")
 
     schema_columns = assembly_component_data_df.columns[assembly_component_data_df.columns.isin(assembly_component_schema_df["term_name"].tolist() + ["accession_ena"])]
     rename_columns = {field["term_name"]: term_mapping[field["copo_name"]].get("ENA",field["term_name"]) for field in assembly_component_schema if field["copo_name"] and field["copo_name"] in term_mapping}
-    assembly_component_data_df.fillna(value="", inplace=True)
+    assembly_component_data_df = assembly_component_data_df.astype(object).fillna("")
     assembly_component_data_df = assembly_component_data_df[schema_columns]
     assembly_component_data_df.rename(columns=rename_columns, inplace=True)
     child_component_data_df_map = dict()
@@ -302,7 +302,7 @@ def _prepare_assembly_submission(singlecell, component_name="assembly"):
     
     sample_component_data = components.get("sample", [])
     sample_component_data_df = pd.DataFrame.from_records(sample_component_data)
-    sample_component_data_df.fillna(value="", inplace=True)
+    sample_component_data_df = sample_component_data_df.astype(object).fillna("")
     sample_component_data_df = sample_component_data_df[[identifier_map["sample"], "biosampleAccession"]]
     assembly_component_data_df = assembly_component_data_df.merge(sample_component_data_df, left_on=parent_map["assembly"]["sample"], right_on=identifier_map["sample"], how="left") 
     assembly_component_data_df["study_accession"] = study_accession
@@ -317,11 +317,11 @@ def _prepare_assembly_submission(singlecell, component_name="assembly"):
             Logger().error(f"Missing schema for component {component} in singlecell submission: {singlecell.get('study_id', 'Unknown')}")
             continue
         child_component_schema_df = pd.DataFrame.from_records(child_component_schema)
-        child_component_schema_df.fillna(value="", inplace=True)
+        child_component_schema_df = child_component_schema_df.astype(object).fillna("")
         child_component_data_df = pd.DataFrame.from_records(child_component_data)
         schema_columns = child_component_data_df.columns[child_component_data_df.columns.isin(child_component_schema_df["term_name"].tolist())]
         rename_columns = {field["term_name"]: term_mapping[field["copo_name"]].get("ENA",field["term_name"]) for field in assembly_component_schema if field["copo_name"] and field["copo_name"] in term_mapping}
-        child_component_data_df.fillna(value="", inplace=True)
+        child_component_data_df = child_component_data_df.astype(object).fillna("")
         child_component_data_df = child_component_data_df[schema_columns]
         child_component_data_df.rename(columns=rename_columns, inplace=True)
         child_component_data_df_map[component] = child_component_data_df
@@ -386,13 +386,13 @@ def _prepare_file_submission(singlecell, file_component_name="file"):
     if not file_component_data:
         return
     file_component_df = pd.DataFrame.from_records(file_component_data)
-    file_component_df.fillna(value="", inplace=True)
+    file_component_df = file_component_df.astype(object).fillna("")
     file_component_schema = schemas.get(file_component_name, {})
     if not file_component_schema:
         Logger().error(f"Missing schema for {file_component_name} component in singlecell submission: {singlecell.get('study_id', 'Unknown')}")
         return
     file_component_schema_df = pd.DataFrame.from_records(file_component_schema)
-    file_component_schema_df.fillna(value="", inplace=True)
+    file_component_schema_df = file_component_schema_df.astype(object).fillna("")
     schema_columns = file_component_df.columns[file_component_df.columns.isin(file_component_schema_df["term_name"].tolist() + ["accession_ena"])]
     rename_columns = {field["term_name"]: term_mapping[field["copo_name"]].get("ENA",field["term_name"]) for field in file_component_schema if field["copo_name"] and field["copo_name"] in term_mapping}
 
@@ -413,14 +413,14 @@ def _merge_paranent_data(component_df, identifier_map, component_name, parent_ma
         if not referenced_component_data:
             continue 
         referenced_component_df = pd.DataFrame.from_records(referenced_component_data)
-        referenced_component_df.fillna(value="", inplace=True)
+        referenced_component_df = referenced_component_df.astype(object).fillna("")
         referenced_component_df.drop(columns=["study_id"], inplace=True, errors='ignore')
         
         referenced_component_schema = schemas.get(referenced_component, {})
         if not referenced_component_schema:
             continue
         referenced_component_schema_df = pd.DataFrame.from_records(referenced_component_schema)
-        referenced_component_schema_df.fillna(value="", inplace=True)
+        referenced_component_schema_df = referenced_component_schema_df.astype(object).fillna("")
 
         schema_columns = referenced_component_df.columns[referenced_component_df.columns.isin(referenced_component_schema_df["term_name"].tolist())]
         rename_columns = {field["term_name"]: term_mapping[field["copo_name"]].get("ENA",field["term_name"]) for field in referenced_component_schema if field["copo_name"] and field["copo_name"] in term_mapping}

--- a/src/apps/copo_single_cell_submission/views.py
+++ b/src/apps/copo_single_cell_submission/views.py
@@ -292,7 +292,9 @@ def save_singlecell_records(request, profile_id, schema_name):
             if field not in component_data_df.columns:
                 component_data_df[field] = additional_fields_default_value_map[field]
             else:
-                component_data_df[field].fillna(additional_fields_default_value_map[field], inplace=True)
+                component_data_df[field] = component_data_df[field].astype(object).fillna(
+                    additional_fields_default_value_map[field]
+                )
                 
         #update status = "pending" for all submission repository
         for repository in submission_repository.get(component_name, []):


### PR DESCRIPTION
Dependabot #175 bumped `pandas` 2.2.3 -> 3.0.3. Three patterns that pandas 2 tolerated now fail. These surfaced as generic 503s on manifest upload and submission journeys.

## The three breakages

**1. `fillna("")` on an all-NaN `float64` column**

```
TypeError: Invalid value '' for dtype 'float64'
```

Schema frames are built with `DataFrame.from_records()` over Mongo docs. An optional schema field left blank for *every* record becomes an all-NaN column, and NaN is a float — so pandas types the whole column `float64`. pandas 2 silently upcast the block to `object` when filling with a string; pandas 3 refuses. Fix: `df = df.astype(object).fillna("")`.

Because this lives in the schema definition rather than user data, it fails deterministically per schema — every upload, regardless of file contents.

**2. `df[col].fillna(x, inplace=True)`**

This mutates a temporary Series, not the DataFrame, so under Copy-on-Write it is a guaranteed silent no-op. pandas 3 raises `ChainedAssignmentError`. Fix: reassign.

Note this **changes runtime behaviour** rather than only preventing an error — those columns were never actually being defaulted. Blank ENA attribute and `accession_*`/`error_*` columns now resolve to `""`/`n/a` instead of staying NaN.

**3. `drop(columns=[...], axis=1)`**

```
ValueError: Cannot specify both 'axis' and 'index'/'columns'
```

The `axis` was always redundant alongside `columns=`; pandas 2 ignored it. Fix: remove it.

## Scope

10 files. Found via an AST scan rather than grep — keyword arguments frequently sit on a following line, so a line-based search misses them.

One flagged site was checked and deliberately left alone: `SingleCellSchemasHandler.py:958` calls `.rename(inplace=True)` on `self.new_data[component]`, but `self.new_data` is a plain dict, so the subscript returns the real DataFrame and `inplace` works correctly.

## Testing

Reproduced the original `TypeError` against the real `EI_EDP` schema in a container running pandas 3.0.3, and confirmed all six checklists build cleanly afterwards. All changed modules compile and import.

**Category 2 needs a real test submission before merge** — the ENA paths now behave differently, and an import check does not cover that.

## Related

The EDP-specific half of this fix is on the `edp` branch (`015af668`), covering `EDPSchemasHandler` and the Sapio adapter.

Worth considering separately: adding `update-types: ["minor", "patch"]` to the Dependabot groups, so a major version bump cannot ride into a PR titled "Bump the data group with 5 updates".
