### PR TITLE
CD-211: Exclude the default ENA sample checklist (ERC000011) as an dropdown menu option

### DIFF
--- a/common/dal/copo_da.py
+++ b/common/dal/copo_da.py
@@ -1448,8 +1448,10 @@ class EnaChecklist(DAComponent):
 
     # obsolete
     def get_sample_checklists_no_fields(self):
+        # Get all sample checklists with 'ERC' or 'read' as the checklist
+        # ID prefix except the default sample checklist (ERC000011)
         return self.get_all_records_columns(
-            filter_by={"primary_id": {"$regex": "^(ERC|read)"}},
+            filter_by={"primary_id": {"$regex": "^(ERC|read)", "$nin": ["ERC000011"]}},
             projection={"primary_id": 1, "name": 1, "description": 1},
         )
 
@@ -1460,8 +1462,10 @@ class EnaChecklist(DAComponent):
         )
 
     def get_general_sample_checklists_no_fields(self):
+        # Get all general sample checklists with 'ERC' or 'COPO' as the checklist
+        # ID prefix except the default sample checklist (ERC000011)
         return self.get_all_records_columns(
-            filter_by={"primary_id": {"$regex": "^(ERC|COPO)"}},
+            filter_by={"primary_id": {"$regex": "^(ERC|COPO)", "$nin": ["ERC000011"]}},
             projection={"primary_id": 1, "name": 1, "description": 1},
         )
 


### PR DESCRIPTION
# COPO Pull Request

## Title
<em>Exclude the default ENA sample checklist (ERC000011) as an dropdown menu option</em>

---

## Jira Link
<em>https://earlham-institute.atlassian.net/browse/CD-211?atlOrigin=eyJpIjoiZDlmZWNkZjY3OGZjNDI4NDlkODk4NmI1NjUzZDY4MzMiLCJwIjoiaiJ9</em>

<em>Exclude ERC000011 from the (general) sample checklist dropdown enu options</em>

---

## Summary of Changes
<em>The code excludes the ERC000011 from the sample checklist dropdown menu.</em>

---

## Checklist Before Requesting Review

- [ ] Jira ticket is in the correct state  
- [ ] Change meets the acceptance criteria  
- [ ] Manual test plan has been followed and passed  
- [ ] No debug prints or experimental code left in  
- [ ] API or schema changes documented  

---

## Testing Evidence
<em>The ERC000011 default sample checklist no longer appears as a dropdown menu option on the (General) `Samples` page under a `Biodata` profile.</em>

---

## Reviewer Notes
<em>The default ENA sample checklist option is recorded in the database. It's just not one of the checklists that is shown to users as a dropdown menu option on the Samples page.</em>

---

## Review Responsibilities

- Developer pull requests: reviewed by Senior Developer  
- Senior Developer's pull requests: reviewed by Manager 
- Manager's pull requests: reviewed by Senior Developer

Confirm the correct reviewer is assigned.

---

## Deployment Notes
>Note whether this change requires config updates, migrations, restarts, or downstream updates.

---

## After Approval

- Move the Jira ticket to the next state  